### PR TITLE
Add test for AddressFamily

### DIFF
--- a/src/Public/General/Test-ValidIPv4Address.ps1
+++ b/src/Public/General/Test-ValidIPv4Address.ps1
@@ -36,8 +36,8 @@ Function Test-ValidIPv4Address {
         IsPrivate   =   $false
     }
 
-    # Check if ID value is an integer
-    if ($IP -as [ipaddress]) {
+    # Check if IP value is a valid IP address, and is IPv4 by parsing it as an [ipaddress]
+    if ($IP -as [ipaddress] -and ($IP -as [ipaddress]).AddressFamily -eq 'InterNetworkV4') {
         $OutObject.Value = $IP.ToString()
         $OutObject.IsValid = $true
         if ($IP -Match '(^127\.)|(^192\.168\.)|(^10\.)|(^172\.1[6-9]\.)|(^172\.2[0-9]\.)|(^172\.3[0-1]\.)') {


### PR DESCRIPTION
Provisional fix for LogRhythm-Tools/LogRhythm.Tools#96 where an IPv6 is considered a valid IPv4.