### PR TITLE
Fixes for Get-LrNetwork

### DIFF
--- a/src/Public/LogRhythm/Admin/Networks/Get-LrNetworks.ps1
+++ b/src/Public/LogRhythm/Admin/Networks/Get-LrNetworks.ps1
@@ -130,11 +130,11 @@ Function Get-LrNetworks {
 
 
         [Parameter(Mandatory = $false, ValueFromPipelineByPropertyName = $true, Position = 4)]
-        [string] $BIP,
+        [ipaddress] $BIP,
 
 
         [Parameter(Mandatory = $false, ValueFromPipelineByPropertyName = $true, Position = 5)]
-        [string] $EIP,
+        [ipaddress] $EIP,
 
 
         [Parameter(Mandatory = $false, ValueFromPipelineByPropertyName = $true, Position = 6)]

--- a/src/Public/LogRhythm/Admin/Networks/Get-LrNetworks.ps1
+++ b/src/Public/LogRhythm/Admin/Networks/Get-LrNetworks.ps1
@@ -285,7 +285,7 @@ Function Get-LrNetworks {
             DO {
                 # Increment Page Count / Offset
                 #$PageCount = $PageCount + 1
-                $Offset = $Offset + 1
+                $Offset += $PageValuesCount
                 # Update Query Paramater
                 $QueryParams.offset = $Offset
                 # Apply to Query String


### PR DESCRIPTION
- Accept BIP and EIP as [ipaddress]
- Fixes for pagination issue that treats offset as a page number when API does item number